### PR TITLE
Make generic scorer easier to inherit

### DIFF
--- a/RNAFoldAssess/models/scorers/DSCI.py
+++ b/RNAFoldAssess/models/scorers/DSCI.py
@@ -5,7 +5,7 @@ from .scorer import Scorer
 
 # This scorer is called the DSCI method and uses the Mann-Whitney U-Test
 
-class DSCI:
+class DSCI(Scorer):
     def __init__(self,
                  data_point=None,
                  secondary_structure=None,

--- a/RNAFoldAssess/models/scorers/base_pair_scorer.py
+++ b/RNAFoldAssess/models/scorers/base_pair_scorer.py
@@ -1,7 +1,7 @@
 from .scorer import Scorer
 
 
-class BasePairScorer:
+class BasePairScorer(Scorer):
     def __init__(self, true_structure, predicted_structure, bp_lenience=0):
         self.true_structure = true_structure
         self.predicted_structure = predicted_structure

--- a/RNAFoldAssess/models/scorers/scorer.py
+++ b/RNAFoldAssess/models/scorers/scorer.py
@@ -3,18 +3,8 @@
 
 
 class Scorer:
-    def __init__(self,
-                 data_point=None,
-                 secondary_structure=None,
-                 algorithm=None,
-                 evaluate_immediately=False,
-                 **kwargs):
-        self.data_point = data_point
-        self.secondary_structure = secondary_structure
-        self.algorithm = algorithm
-        self.metrics = {}
-        if evaluate_immediately:
-            self.evaluate()
+    def __init__(self, *args, **kwargs):
+        pass
 
     def evaluate(self):
         # Override this method to apply the scoring technique you are writing.


### PR DESCRIPTION
I want to enforce that scorers inherit the `Scorer` method so that I can enforce the `report` and `evaluate` methods on all subtypes. To do that, I have to make the base class a little less opinionated about its constructor.