### PR TITLE
ContextFold fix doesn't work

### DIFF
--- a/tests/test_context_fold.py
+++ b/tests/test_context_fold.py
@@ -11,6 +11,8 @@ class TestContextFold:
     input_file_path = datum.sequence # Not actually a file but keeping it for consistency
     model = ContextFold()
     model_path = path.Path("/home/yesselmanlab/ewhiting/ContextFold_1_00").abspath()
+    # HCC Housekeeping
+    os.system("module load java")
 
     def test_prediction(self):
         self.model.execute(self.model_path, self.input_file_path)

--- a/tests/test_rna_structure.py
+++ b/tests/test_rna_structure.py
@@ -12,7 +12,8 @@ class TestRNAStructure:
     model_path = "/util/opt/anaconda/deployed-conda-envs/packages/rnastructure/envs/rnastructure-6.1/bin/Fold"
     # HCC Swan housekeeping:
     os.system("module load rnastructure")
-    os.system("export DATAPATH=/util/opt/anaconda/deployed-conda-envs/packages/rnastructure/envs/rnastructure-6.1/share/rnastructure/data_tables")
+    datapath = "/util/opt/anaconda/deployed-conda-envs/packages/rnastructure/envs/rnastructure-6.1/share/rnastructure/data_tables"
+    os.environ["DATAPATH"] = datapath
 
     def test_prediction(self):
         input_file_path = self.datum.to_fasta_file()


### PR DESCRIPTION
It looks like you have to actually run `module load java` manually in the terminal to get context fold to work. I don't know why `os.system("module load java")` doesn't work, and I don't know why it suddenly doesn't work either. Whatever.