### PR TITLE
Ipknot predictor

### DIFF
--- a/RNAFoldAssess/models/predictors/__init__.py
+++ b/RNAFoldAssess/models/predictors/__init__.py
@@ -6,3 +6,4 @@ from .deep_fold import *
 from .rna_fold import *
 from .rna_structure import *
 from .random_predictor import *
+from .ipknot import *

--- a/RNAFoldAssess/models/predictors/ipknot.py
+++ b/RNAFoldAssess/models/predictors/ipknot.py
@@ -1,0 +1,28 @@
+import os
+
+
+class IPknot:
+    def __init__(self):
+        self.output = ""
+
+    def execute(self, path, fasta_file, remove_file_when_done=True):
+        path_to_ipknot = os.path.abspath(path)
+        exec_string = f"{path} {fasta_file}"
+        self.output = os.popen(exec_string).read()
+        if remove_file_when_done:
+            os.remove(fasta_file)
+
+    def get_ss_prediction(self):
+        if self.output == "":
+            raise Exception(f"IPknot exception: no output generated")
+        strings = self.output.split("\n")
+        ss = strings[-2]
+        return ss
+
+    def get_ss_prediction_ignore_pseudoknots(self):
+        if self.output == "":
+            raise Exception(f"IPknot exception: no output generated")
+        strings = self.output.split("\n")
+        ss = strings[-2]
+        ss = ss.replace("[", ".").replace("]", ".")
+        return ss

--- a/RNAFoldAssess/models/predictors/mxfold.py
+++ b/RNAFoldAssess/models/predictors/mxfold.py
@@ -10,8 +10,10 @@ class MXFold:
         exec_string = f"{path} {fasta_file}"
         self.output = os.popen(exec_string).read()
         if remove_file_when_done:
-            # print(f"MXFold object is deleting {fasta_file}")
-            os.remove(fasta_file)
+            try:
+                os.remove(fasta_file)
+            except FileNotFoundError:
+                print(f"MXFold: Couldn't find {fasta_file} to delete")
 
     def get_ss_prediction(self):
         if self.output == "":

--- a/RNAFoldAssess/models/predictors/rna_fold.py
+++ b/RNAFoldAssess/models/predictors/rna_fold.py
@@ -15,7 +15,10 @@ class RNAFold:
         self.output = os.popen(exec_string).read()
         file_name_base = fasta_file.split(".")[0]
         if delete_input_file_immediately:
-            os.system(f"rm {file_name_base}*")
+            try:
+                os.system(f"rm {file_name_base}*")
+            except FileNotFoundError:
+                print(f"RNAFold: Couldn't find {file_name_base} files to delete")
 
     def get_ss_prediction(self):
         if self.output == "":

--- a/RNAFoldAssess/models/scorers/__init__.py
+++ b/RNAFoldAssess/models/scorers/__init__.py
@@ -1,3 +1,4 @@
 from .scorer import *
 from .DSCI import *
 from .base_pair_scorer import *
+from .base_pair_pseudoknot_scorer import *

--- a/RNAFoldAssess/models/scorers/base_pair_pseudoknot_scorer.py
+++ b/RNAFoldAssess/models/scorers/base_pair_pseudoknot_scorer.py
@@ -1,0 +1,173 @@
+from .scorer import Scorer
+
+
+class BasePairPseudoknotScorer(Scorer):
+    def __init__(self, true_structure, predicted_structure, bp_lenience=0):
+        self.true_structure = true_structure
+        self.predicted_structure = predicted_structure
+        self.bp_lenience = bp_lenience
+        self.true_structure = BasePairPseudoknotScorer.parse_structure(self.true_structure)
+        self.predicted_structure = BasePairPseudoknotScorer.parse_structure(self.predicted_structure)
+        self.acceptable_locations = {"basepairs": [], "pseudoknots": []}
+        self.tp = 0
+        self.fp = 0
+        self.fn = 0
+        self.get_acceptable_locations()
+        self.get_false_negatives()
+        self.get_tp_and_fp()
+
+    def evaluate(self):
+        if (self.tp + self.fn) == 0:
+            self.sensitivity = 0.0
+        else:
+            self.sensitivity = self.tp / (self.tp + self.fn)
+
+        if (self.tp + self.fp) == 0:
+            self.ppv = 0
+        else:
+            self.ppv = self.tp / (self.tp + self.fp)
+
+        if (self.sensitivity + self.ppv) == 0:
+            self.f1 = 0
+        else:
+            self.f1 = (2 * self.sensitivity * self.ppv) / (self.sensitivity + self.ppv)
+
+    def get_tp_and_fp(self):
+        for pred_bp in self.predicted_structure["basepairs"]:
+            if pred_bp in self.acceptable_locations["basepairs"]:
+                self.tp += 1
+            else:
+                self.fp += 1
+
+        for pred_pk in self.predicted_structure["pseudoknots"]:
+            if pred_pk in self.acceptable_locations["pseudoknots"]:
+                self.tp += 1
+            else:
+                self.fp += 1
+
+    def get_false_negatives(self):
+        fn = 0
+        if len(self.true_structure["basepairs"]) > 0 and len(self.predicted_structure["basepairs"]) == 0:
+            self.fn += len(self.true_structure["basepairs"])
+        else:
+            for bp in self.true_structure["basepairs"]:
+                pos_locs = [bp]
+                i, j = bp
+                for r in range(self.bp_lenience):
+                    e = r + 1
+                    pos_locs.append((i + e, j))
+                    pos_locs.append((i, j + e))
+                    pos_locs.append((i - e, j))
+                    pos_locs.append((i, j - e))
+
+                for pbp in self.predicted_structure["basepairs"]:
+                    if pbp in pos_locs:
+                        fn = 0
+                        break
+                    else:
+                        fn = 1
+                self.fn += fn
+
+        if len(self.true_structure["pseudoknots"]) > 0 and len(self.predicted_structure["pseudoknots"]) == 0:
+            self.fn += len(self.true_structure["pseudoknots"])
+        else:
+            for pk in self.true_structure["pseudoknots"]:
+                pos_locs = [pk]
+                i, j = pk
+                for r in range(self.bp_lenience):
+                    e = r + 1
+                    pos_locs.append((i + e, j))
+                    pos_locs.append((i, j + e))
+                    pos_locs.append((i - e, j))
+                    pos_locs.append((i, j - e))
+
+                for ppk in self.predicted_structure["pseudoknots"]:
+                    if ppk in pos_locs:
+                        fn = 0
+                        break
+                    else:
+                        fn = 1
+                self.fn += fn
+
+
+
+    def get_acceptable_locations(self):
+        """
+        Get all acceptable locations given the provided leniency. In other
+        words, if lenience of 1, add one of the true locations is (2, 4),
+        we need to add (3, 4), (2, 5), (1, 4), and (1, 3) to the list of
+        acceptable locations. With this list, we can check each predicted
+        location against the acceptable location and successfully record
+        either a true positive or false positive.
+        """
+        for true_bp in self.true_structure["basepairs"]:
+            self.acceptable_locations["basepairs"].append(true_bp) # (i, j)
+            real_start, real_end = true_bp
+            for i in range(self.bp_lenience):
+                lenience = i + 1
+                self.acceptable_locations["basepairs"].append((real_start + lenience, real_end)) # (i + e, j)
+                self.acceptable_locations["basepairs"].append((real_start, real_end + lenience)) # (i, j + e)
+                self.acceptable_locations["basepairs"].append((real_start - lenience, real_end)) # (i - e, j)
+                self.acceptable_locations["basepairs"].append((real_start, real_end - lenience)) # (i, j - e)
+
+        for true_bp in self.true_structure["pseudoknots"]:
+            self.acceptable_locations["pseudoknots"].append(true_bp) # (i, j)
+            real_start, real_end = true_bp
+            for i in range(self.bp_lenience):
+                lenience = i + 1
+                self.acceptable_locations["pseudoknots"].append((real_start + lenience, real_end)) # (i + e, j)
+                self.acceptable_locations["pseudoknots"].append((real_start, real_end + lenience)) # (i, j + e)
+                self.acceptable_locations["pseudoknots"].append((real_start - lenience, real_end)) # (i - e, j)
+                self.acceptable_locations["pseudoknots"].append((real_start, real_end - lenience)) # (i, j - e)
+
+
+    def report(self, precision=3):
+        report = f"Sensitivity: {round(self.sensitivity, precision)}, "
+        report += f"PPV: {round(self.ppv, precision)}, "
+        report += f"F1: {round(self.f1, precision)}"
+        return report
+
+
+    @staticmethod
+    def parse_structure(structure):
+        return {
+            "basepairs": BasePairPseudoknotScorer.get_base_pairs(structure),
+            "pseudoknots": BasePairPseudoknotScorer.get_psuedoknots(structure)
+        }
+
+
+    @staticmethod
+    def get_base_pairs(structure):
+        # structure exampe: "..((((...))))..((..))."
+        bps = []
+        for i1, c1 in enumerate(structure):
+            if c1 != '(':
+                continue
+            count = 1
+            for i2, c2 in enumerate(structure[i1 + 1:]):
+                if c2 == '(':
+                    count += 1
+                elif c2 == ')':
+                    count -= 1
+                    if count == 0:
+                        bps.append((i1, i1 + i2 + 1))
+                        break
+        return bps
+
+    @staticmethod
+    def get_psuedoknots(structure):
+        # structure example: .((((((..[[[[..(((((.]]]]......[[........)))))..(((((....]].))))))))))).....
+        knots = []
+        for i1, c1 in enumerate(structure):
+            if c1 != '[':
+                continue
+            count = 1
+            for i2, c2 in enumerate(structure[i1 + 1:]):
+                if c2 == '[':
+                    count += 1
+                elif c2 == ']':
+                    count -= 1
+                    if count == 0:
+                        knots.append((i1, i1 + i2 + 1))
+                        break
+        return knots

--- a/RNAFoldAssess/models/scorers/base_pair_scorer.py
+++ b/RNAFoldAssess/models/scorers/base_pair_scorer.py
@@ -41,23 +41,26 @@ class BasePairScorer(Scorer):
 
     def get_false_negatives(self):
         fn = 0
-        for bp in self.true_structure:
-            pos_locs = [bp]
-            i, j = bp
-            for r in range(self.bp_lenience):
-                e = r + 1
-                pos_locs.append((i + e, j))
-                pos_locs.append((i, j + e))
-                pos_locs.append((i - e, j))
-                pos_locs.append((i, j - e))
+        if len(self.true_structure) > 0 and len(self.predicted_structure) == 0:
+            self.fn += len(self.true_structure)
+        else:
+            for bp in self.true_structure:
+                pos_locs = [bp]
+                i, j = bp
+                for r in range(self.bp_lenience):
+                    e = r + 1
+                    pos_locs.append((i + e, j))
+                    pos_locs.append((i, j + e))
+                    pos_locs.append((i - e, j))
+                    pos_locs.append((i, j - e))
 
-            for pbp in self.predicted_structure:
-                if pbp in pos_locs:
-                    fn = 0
-                    break
-                else:
-                    fn = 1
-            self.fn += fn
+                for pbp in self.predicted_structure:
+                    if pbp in pos_locs:
+                        fn = 0
+                        break
+                    else:
+                        fn = 1
+                self.fn += fn
 
     def get_acceptable_locations(self):
         """

--- a/tests/test_ipknot.py
+++ b/tests/test_ipknot.py
@@ -1,0 +1,27 @@
+import path, os
+
+from RNAFoldAssess.models import IPknot, DataPoint
+from RNAFoldAssess.models import DSCI
+
+
+class TestIPknot:
+    # Testing with C009C
+    base_data_path = "/common/yesselmanlab/ewhiting/ss_deeplearning_data/data"
+    datum = DataPoint.factory(f'{base_data_path}/C009C.json')[0]
+    input_file_path = datum.to_fasta_file()
+    model = IPknot()
+    model_path = path.Path("/common/yesselmanlab/ewhiting/ipknot-1.1.0-x86_64-linux/ipknot").abspath()
+
+    def test_prediction(self):
+        self.model.execute(self.model_path, self.input_file_path, remove_file_when_done=False)
+        prediction = self.model.get_ss_prediction()
+        scorer = DSCI(self.datum, self.model.get_ss_prediction(), 'IPknot', evaluate_immediately=True, DMS=True)
+        metrics = scorer.metrics
+        assert(metrics['accuracy'] > 0.7)
+
+    def test_non_pseudoknot_prediction(self):
+        self.model.execute(self.model_path, self.input_file_path)
+        prediction = self.model.get_ss_prediction_ignore_pseudoknots()
+        scorer = DSCI(self.datum, self.model.get_ss_prediction(), 'IPknot', evaluate_immediately=True, DMS=True)
+        metrics = scorer.metrics
+        assert(metrics['accuracy'] > 0.7)

--- a/tests/test_random_predictor.py
+++ b/tests/test_random_predictor.py
@@ -11,6 +11,5 @@ class TestRandomPredictor:
 
     def test_prediction(self):
         self.model.execute(fasta_file=self.input_file_path)
-        os.remove(self.input_file_path)
         prediction = self.model.get_ss_prediction()
         assert(len(prediction) == len(self.datum.sequence))

--- a/tests/test_scorers.py
+++ b/tests/test_scorers.py
@@ -238,6 +238,28 @@ class TestBasePairScorer:
         scorer.evaluate()
         assert(scorer.fn == 2)
 
+    def test_false_negative_calculation7(self):
+        real = "..(..).."
+        pred = "........"
+        scorer = BasePairScorer(real, pred)
+        scorer.evaluate()
+        assert(scorer.fn == 1)
+
+    def test_false_negative_calculation8(self):
+        real = "..(..)..(..)..(...).."
+        pred = "....................."
+        scorer = BasePairScorer(real, pred)
+        scorer.evaluate()
+        assert(scorer.fn == 3)
+
+
+    def test_false_negative_calculation9(self):
+        real = "..........."
+        pred = "..........."
+        scorer = BasePairScorer(real, pred)
+        scorer.evaluate()
+        assert(scorer.fn == 0)
+
     def test_perfect_match(self):
         scorer = BasePairScorer(self.real, self.real)
         scorer.evaluate()


### PR DESCRIPTION
This pull request adds IPknot to the list of predictors as well as a scorer for predictions containing pseudoknot annotation.

When writing the tests for the new scorer, it became clear that there is bug hidden in `BasePairScorer`.  Basically, the scorer will not count false negatives if the `predicted_structure` attribute is an empty list. This means any analyses run with this scorer up until now are probably wrong. This PR includes a fix for that bug in commit 31b02ff227909e3c8c512be30a63939c746669f7.

Finally, I added some error handling around the models not finding files they're supposed to delete. It was mainly to support testing, but didn't seem to make a difference. However, this will probably help in future pipelines when gathering partial results.